### PR TITLE
Fix anchor for toc

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -92,7 +92,7 @@ def print_action_groups(data, nested_content, markdown_help=False, settings=None
     if 'action_groups' in data:
         for action_group in data['action_groups']:
             # Every action group is comprised of a section, holding a title, the description, and the option group (members)
-            section = nodes.section(ids=[action_group['title']])
+            section = nodes.section(ids=[action_group['title'].replace(' ', '-').lower()])
             section += nodes.title(action_group['title'], action_group['title'])
 
             desc = []


### PR DESCRIPTION
This PR fixes the problem that the ToC does not recognize generated anchors with space, e.g., `Positional Arguments`.

![image](https://user-images.githubusercontent.com/4057569/133691586-b841a700-caf6-4abb-bc7a-41a1a3f2f519.png)