### PR TITLE
remove colon from the title

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -185,8 +185,8 @@ def print_subcommands(data, nested_content, markdown_help=False, settings=None):
     definitions = map_nested_definitions(nested_content)
     items = []
     if 'children' in data:
-        subcommands = nodes.section(ids=["Sub-commands:"])
-        subcommands += nodes.title('Sub-commands:', 'Sub-commands:')
+        subcommands = nodes.section(ids=["Sub-commands"])
+        subcommands += nodes.title('Sub-commands', 'Sub-commands')
 
         for child in data['children']:
             sec = nodes.section(ids=[child['name']])


### PR DESCRIPTION
It looks a bit strange that a colon is in the title:

![image](https://user-images.githubusercontent.com/9496702/174558938-ed4db6c4-9e89-45d4-be21-187b44e030a6.png)
