### PR TITLE
Fix link to github repo in docs Contribute page

### DIFF
--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -9,7 +9,7 @@ Most wanted:
  * Bug fixes
  * Examples
 
-Contributions are gratefully accepted through `github <https://github.com/ribozz/sphinx-argparse>`_ pull-request. Please report bugs as issues on github.
+Contributions are gratefully accepted through `github <https://github.com/ashb/sphinx-argparse>`_ pull-request. Please report bugs as issues on github.
 
 Don't forget to run tests before committing::
 


### PR DESCRIPTION
Hi there, and thanks for your work on sphinx-argparse (we just started using it for https://fractal-analytics-platform.github.io/fractal/cli.html). This is a microscopic PR to fix a link in the Contribute docs page, that is currently pointing to the old github repository.